### PR TITLE
Add landscape option

### DIFF
--- a/src/createPdf.ts
+++ b/src/createPdf.ts
@@ -46,6 +46,7 @@ export default async (options: Options) => {
     // https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
     const pdf = await page.pdf({
       format: options.format,
+      landscape: options.landscape,
       margin: { top: 0, right: 0, bottom: 0, left: 0 },
       printBackground: true,
     });

--- a/src/optionParser.ts
+++ b/src/optionParser.ts
@@ -37,7 +37,7 @@ commander
   .option("--user-agent <string>", "user agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3312.0 Safari/537.36")
   .option("--timeout <number>", "time out ms", 30000)
   .option("--wait-for <number>", "wait for ms", 250)
-  .option("--landscape <boolean>", "landscape pdf file", false)
+  .option("--landscape", "landscape pdf file", false)
   .usage("--path index.html --out index.pdf");
 
 export default (argv): Options => {

--- a/src/optionParser.ts
+++ b/src/optionParser.ts
@@ -10,6 +10,7 @@ export interface Options {
   timeout: number;
   waitFor: number;
   userAgent: string;
+  landscape: boolean;
 }
 
 export const formats = [
@@ -36,6 +37,7 @@ commander
   .option("--user-agent <string>", "user agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3312.0 Safari/537.36")
   .option("--timeout <number>", "time out ms", 30000)
   .option("--wait-for <number>", "wait for ms", 250)
+  .option("--landscape <boolean>", "landscape pdf file", false)
   .usage("--path index.html --out index.pdf");
 
 export default (argv): Options => {
@@ -49,5 +51,6 @@ export default (argv): Options => {
     timeout: commander.timeout,
     waitFor: commander.waitFor,
     userAgent: commander.userAgent,
+    landscape: commander.landscape
   } as Options;
 };


### PR DESCRIPTION
# Summary

page.pdf has landscape options, so add it.

<img width="897" alt="puppeteer:api md at master · GoogleChrome:puppeteer 2019-10-25 14-26-53" src="https://user-images.githubusercontent.com/8898432/67545277-86e41c80-f733-11e9-9dca-bf977045b104.png">
ref: https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions